### PR TITLE
Don't skip shared thread creation when main ractor disabled mn threads

### DIFF
--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -379,7 +379,8 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
     rb_native_mutex_lock(&vm->ractor.sched.lock);
     {
         unsigned int snt_cnt = vm->ractor.sched.snt_cnt;
-        if (!vm->ractor.main_ractor->threads.sched.enable_mn_threads) snt_cnt++; // do not need snt for main ractor
+        // create at least one shared thread with max_cpu 1 case.
+        if (!vm->ractor.main_ractor->threads.sched.enable_mn_threads && vm->ractor.sched.max_cpu > 1) snt_cnt++;
 
         if (((int)snt_cnt < MINIMUM_SNT) ||
             (snt_cnt < vm->ractor.cnt  &&


### PR DESCRIPTION
with RUBY_MAX_CPU=1, vm can't get shared thread for ractors. Thread creation request to vm via Thread class (without RUBY_MN_THREADS) calls native_thread_create_dedicated, so this if clause has no effect except Ractor creation.